### PR TITLE
Token saved to env file, can be run as separate script or part of test

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -40,7 +40,7 @@ describe('Setup', () => {
 
   it('It has to mock cognito', () => {            
     cognitoISP.addToCognitoGroup().then( res => {
-      console.info('cognitoISP', res)      
+      console.info('cognitoISP')      
     })
     expect(cognitoISP.addToCognitoGroup).toHaveBeenCalled();
   }) 
@@ -60,6 +60,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/users')      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -71,6 +72,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/users/' + testUser.id)      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -84,6 +86,7 @@ describe('Integration Tests', () => {
         .post(versionString + '/users')
         .send(testUser)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -98,6 +101,7 @@ describe('Integration Tests', () => {
         .put(versionString + '/users/' + testUser.id)
         .send({email: email})
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -110,6 +114,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .delete(versionString + '/users/' + testUser.id)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);     
     });
@@ -118,7 +123,10 @@ describe('Integration Tests', () => {
   describe('Org API', () => {    
 
     it('It should return all /orgs on GET', async () => {
-      const { res, req } = await request(app).get(versionString + '/orgs')      
+      const { res, req } = await request(app)
+        .get(versionString + '/orgs')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
+
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
       _dbOrgs = new RandItems(JSON.parse(res.text))
@@ -129,6 +137,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/orgs/' + testOrg.id)      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -143,6 +152,7 @@ describe('Integration Tests', () => {
         .post(versionString + '/orgs')
         .send(testOrg)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -157,6 +167,7 @@ describe('Integration Tests', () => {
         .put(versionString + '/orgs/' + testOrg.id)
         .send({email: email})
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -169,6 +180,7 @@ describe('Integration Tests', () => {
       let response = await request(app)
         .get(versionString + '/orgs/' + testOrg.id)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       const orgRes = response.res 
       expect(orgRes.statusCode).toEqual(200);        
@@ -179,7 +191,8 @@ describe('Integration Tests', () => {
       const testMember = _dbMembers.random()
       response = await request(app)
         .get(versionString + '/users/' + testMember.id)
-        .set('Accept', 'application/json')
+        .set('Accept', 'application/json')         
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       const userRes = response.res
       expect(userRes.statusCode).toEqual(200)
@@ -192,6 +205,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .delete(versionString + '/orgs/' + testOrg.id)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200); 
     });
@@ -203,6 +217,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/notifs')
         .set('Accept', 'application/json') 
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()
@@ -214,6 +229,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/notifs/' + testNotif.id)      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -229,6 +245,7 @@ describe('Integration Tests', () => {
         .post(versionString + '/notifs')
         .send(testNotif)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -243,6 +260,7 @@ describe('Integration Tests', () => {
         .put(versionString + '/notifs/' + testNotif.id)
         .send({title: title})
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -255,6 +273,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .delete(versionString + '/notifs/' + testNotif.id)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200); 
     });
@@ -267,6 +286,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/offers')      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()
@@ -278,6 +298,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .get(versionString + '/offers/' + testOffer.id)      
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -292,6 +313,7 @@ describe('Integration Tests', () => {
         .post(versionString + '/offers')
         .send(testOffer)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -306,6 +328,7 @@ describe('Integration Tests', () => {
         .put(versionString + '/offers/' + testOffer.id)
         .send({title: title})
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200);
       expect(res.text).toBeDefined()    
@@ -318,6 +341,7 @@ describe('Integration Tests', () => {
       const { res, req } = await request(app)
         .delete(versionString + '/offers/' + testOffer.id)
         .set('Accept', 'application/json')
+        .set('accesstoken', process.env.AUTH_ACCESS_TOKEN)
 
       expect(res.statusCode).toEqual(200); 
     });

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "migrate:seed": "knex seed:run",
     "dev": "nodemon -r dotenv/config src/app.js",
     "dev:tunnel": "sh scripts/tunnel.sh && npm run dev",
-    "test": "jest --setupFiles dotenv/config",
-    "coverage": "jest --collectCoverageFrom=src/**.js --coverage"
+    "test": "npm run token && jest --setupFiles dotenv/config",
+    "coverage": "jest --collectCoverageFrom=src/**.js --coverage",
+    "token": "node -r dotenv/config scripts/saveCognitoTokenToEnvFile.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/saveCognitoTokenToEnvFile.js
+++ b/scripts/saveCognitoTokenToEnvFile.js
@@ -1,0 +1,31 @@
+const cognito = require('../src/connections/cognito');
+const fs = require('fs')
+
+const authRequest = {
+  "AuthFlow": "ADMIN_NO_SRP_AUTH",
+  "AuthParameters": { 
+     "USERNAME": process.env.COGNITO_TEST_USERNAME,
+     "PASSWORD": process.env.COGNITO_TEST_PASSWORD
+  },
+  "ClientId": process.env.COGNITO_CLIENT_ID,
+  "UserPoolId": process.env.COGNITO_POOL_ID
+}
+
+let saveFile = ''
+
+cognito.initAuth(authRequest).then( res => {
+  let modified = false
+  fs.readFileSync('.env').toString().split("\n").forEach( (line) => {  
+    if (line.startsWith('AUTH_ACCESS_TOKEN')) {
+      line = line.split('=')[0] + '=' + res.AuthenticationResult.AccessToken
+      modified = true
+    }
+    saveFile += line.toString() + "\n" 
+  })
+
+  if (!modified) saveFile +=  'AUTH_ACCESS_TOKEN=' + res.AuthenticationResult.AccessToken + '\n'
+
+  fs.writeFile('.env', saveFile, 'utf8', function (err) {
+    if (err) return console.error(err);
+  });
+})

--- a/src/connections/cognito.js
+++ b/src/connections/cognito.js
@@ -4,7 +4,9 @@ const cognitoISP = new Cognito({apiVersion: '2016-04-18'})
 
 const cognitoPoolId = require('../config/env').cognitoPoolId;
 
-cognitoISP.addToCognitoGroup = (circlesUser) => {
+let cognito = {}
+
+cognito.addToCognitoGroup = (circlesUser) => {
   const groupName = 'user'
   const params = {
     GroupName: groupName,
@@ -24,4 +26,13 @@ cognitoISP.addToCognitoGroup = (circlesUser) => {
   })
 }
 
-module.exports = cognitoISP
+cognito.initAuth = (authRequest) => {
+  return new Promise((resolve, reject) => {
+    cognitoISP.adminInitiateAuth(authRequest, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)      
+    })
+  })
+}
+
+module.exports = cognito

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -6,7 +6,7 @@ const jwkToPem = require('jwk-to-pem')
 
 const authMiddleWare = (req, res, next) => {
   const token = req.headers['accesstoken']
-  // decode token
+  
   if (token) {
     const pem = jwkToPem(cognitoPoolJWTToken)
     // verifies secret and checks exp
@@ -16,11 +16,8 @@ const authMiddleWare = (req, res, next) => {
       }
       res.locals.user = decodedToken
       next()
-    })
-  } else if (process.env.NODE_ENV === 'test') {
-    next()
-  }
-  else {
+    })  
+  } else {
     // if there is no token
     // return an error()
     return res.status(HttpStatus.UNAUTHORIZED).send({ error: "Must provide accesstoken in header" });


### PR DESCRIPTION
`"token": "node -r dotenv/config scripts/saveCognitoTokenToEnvFile.js"`

loads envs and then runs script which initiates auth and saves the token to the `.env` file.

then when tests are run you will have access to a valid token in the `AUTH_ACCESS_TOKEN` env var:

`"test": "npm run token && jest --setupFiles dotenv/config",`