### PR TITLE
Feature/suggested-contacts

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,6 +23,7 @@ CRUD app for user and organization profiles
 	
 - [Users](#users)
 	- [Delete User&#39;s own record](#delete-user&#39;s-own-record)
+	- [Get a list of suggested Circles contacts](#get-a-list-of-suggested-circles-contacts)
 	- [Request User&#39;s own record](#request-user&#39;s-own-record)
 	- [Create User&#39;s own record](#create-user&#39;s-own-record)
 	- [Update User&#39;s own record](#update-user&#39;s-own-record)
@@ -413,6 +414,26 @@ CRUD app for user and organization profiles
 | Name     | Type       | Description                           |
 |:---------|:-----------|:--------------------------------------|
 |  None |  | <p>Returns nothing on success.</p>|
+
+## <a name='get-a-list-of-suggested-circles-contacts'></a> Get a list of suggested Circles contacts
+[Back to top](#top)
+
+
+
+	POST /users/contacts
+
+
+
+
+
+
+### Success 200
+
+| Name     | Type       | Description                           |
+|:---------|:-----------|:--------------------------------------|
+|  contacts | Object[] | <p>List of contacts that are Circles users.</p>|
+| &nbsp;&nbsp;&nbsp;&nbsp; contacts.id | String | <p>Phone specific contact Id.</p>|
+| &nbsp;&nbsp;&nbsp;&nbsp; contacts.number | String | <p>Phone number of contact.</p>|
 
 ## <a name='request-user&#39;s-own-record'></a> Request User&#39;s own record
 [Back to top](#top)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ CRUD app for user and organization profiles
 	
 - [Users](#users)
 	- [Delete User&#39;s own record](#delete-user&#39;s-own-record)
+	- [Get a list of suggested Circles contacts](#get-a-list-of-suggested-circles-contacts)
 	- [Request User&#39;s own record](#request-user&#39;s-own-record)
 	- [Create User&#39;s own record](#create-user&#39;s-own-record)
 	- [Update User&#39;s own record](#update-user&#39;s-own-record)
@@ -422,6 +423,26 @@ CRUD app for user and organization profiles
 | Name     | Type       | Description                           |
 |:---------|:-----------|:--------------------------------------|
 |  None |  | <p>Returns nothing on success.</p>|
+
+## <a name='get-a-list-of-suggested-circles-contacts'></a> Get a list of suggested Circles contacts
+[Back to top](#top)
+
+
+
+	POST /users/contacts
+
+
+
+
+
+
+### Success 200
+
+| Name     | Type       | Description                           |
+|:---------|:-----------|:--------------------------------------|
+|  contacts | Object[] | <p>List of contacts that are Circles users.</p>|
+| &nbsp;&nbsp;&nbsp;&nbsp; contacts.id | String | <p>Phone specific contact Id.</p>|
+| &nbsp;&nbsp;&nbsp;&nbsp; contacts.number | String | <p>Phone number of contact.</p>|
 
 ## <a name='request-user&#39;s-own-record'></a> Request User&#39;s own record
 [Back to top](#top)

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -174,6 +174,22 @@ async function deleteOwn (req, res) {
   }
 }
 
+async function getSuggestedContacts (req, res) {
+  try {
+    let contacts = JSON.parse(req.body.contacts)    
+    let numbers = contacts.map(contact => contact.number)
+    const users = await User.query()
+      .whereIn('phone_number', numbers)
+    if (!users) return res.sendStatus(404)
+    let suggestedNumbers = users.map(user => user.phone_number)
+    let suggestedContacts = contacts.filter(contact => suggestedNumbers.includes(contact.number))
+    res.status(200).send(suggestedContacts)
+  } catch (error) {
+    logger.error(error.message)
+    res.sendStatus(500)
+  }
+}
+
 module.exports = {
   all,
   own,
@@ -183,5 +199,6 @@ module.exports = {
   updateOne,
   updateOwn,
   deleteOne,
-  deleteOwn
+  deleteOwn,
+  getSuggestedContacts
 }

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -178,7 +178,9 @@ async function getSuggestedContacts (req, res) {
   try {
     let contacts = JSON.parse(req.body.contacts)
     let numbers = contacts.map(contact => contact.number)
-    const users = await User.query().whereIn('phone_number', numbers)
+    const users = await User.query()
+      .whereIn('phone_number', numbers)
+      .andWhere('agreed_to_disclaimer', true)
     if (!users) return res.sendStatus(404)
     let suggestedNumbers = users.map(user => user.phone_number)
     let suggestedContacts = contacts.filter(contact =>

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -176,13 +176,14 @@ async function deleteOwn (req, res) {
 
 async function getSuggestedContacts (req, res) {
   try {
-    let contacts = JSON.parse(req.body.contacts)    
+    let contacts = JSON.parse(req.body.contacts)
     let numbers = contacts.map(contact => contact.number)
-    const users = await User.query()
-      .whereIn('phone_number', numbers)
+    const users = await User.query().whereIn('phone_number', numbers)
     if (!users) return res.sendStatus(404)
     let suggestedNumbers = users.map(user => user.phone_number)
-    let suggestedContacts = contacts.filter(contact => suggestedNumbers.includes(contact.number))
+    let suggestedContacts = contacts.filter(contact =>
+      suggestedNumbers.includes(contact.number)
+    )
     res.status(200).send(suggestedContacts)
   } catch (error) {
     logger.error(error.message)

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -95,9 +95,6 @@ router.delete(
  * @apiSuccess (Success 200) {String} contacts.id   Phone specific contact Id.
  * @apiSuccess (Success 200) {String} contacts.number Phone number of contact.
  */
-router.post(
-  '/contacts',
-  usersController.getSuggestedContacts
-)
+router.post('/contacts', usersController.getSuggestedContacts)
 
 module.exports = router

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -95,6 +95,9 @@ router.delete(
  * @apiSuccess (Success 200) {String} contacts.id   Phone specific contact Id.
  * @apiSuccess (Success 200) {String} contacts.number Phone number of contact.
  */
-router.post('/contacts', usersController.getSuggestedContacts)
+router.post('/contacts', 
+  hasPermissionMiddleware('ownUser'),
+  usersController.getSuggestedContacts
+)
 
 module.exports = router

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -84,4 +84,20 @@ router.delete(
   usersController.deleteOwn
 )
 
+/**
+ * @api {post} /users/contacts Get a list of suggested Circles contacts
+ * @apiName GetSuggestedContacts
+ * @apiGroup Users
+ * @apiVersion 1.1.2
+ * @apiPermission user, admin
+ *
+ * @apiSuccess (Success 200) {Object[]} contacts List of contacts that are Circles users.
+ * @apiSuccess (Success 200) {String} contacts.id   Phone specific contact Id.
+ * @apiSuccess (Success 200) {String} contacts.number Phone number of contact.
+ */
+router.post(
+  '/contacts',
+  usersController.getSuggestedContacts
+)
+
 module.exports = router


### PR DESCRIPTION
Client posts a list of contact `ids` and `number`s to enpoint `/users/contacts`

API filters this list and returns just the entries that are *registered* (`agreed_to_disclaimer === true`).

`Contacts` page then shows the Circles Contacts at the top and the rest below.