### PR TITLE
Account recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/*
 .env
 build/*
 tunnel.sh
+doc/**

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -20,7 +20,6 @@ const packSignature = signature => {
 }
 
 const recoverAddress = async (message, signature) => {
-  
   const messageHash = await Hash.keccak256(
     hexStringToUint8Array(`0x${message.toString(16)}`)
   )

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -19,12 +19,11 @@ const packSignature = signature => {
   return `{signature.r}{signature.s.substring(2);}{Web3.utils.toHex(ethersSignature.v).substring(2)}`
 }
 
-const recoverAddress = async (message, signature, key) => {
+const recoverAddress = async (message, signature) => {
+  
   const messageHash = await Hash.keccak256(
     hexStringToUint8Array(`0x${message.toString(16)}`)
   )
-  const s = await Account.sign(messageHash, key)
-  const vrs = await Account.decodeSignature(s)
   const web3Formatting = {
     message: message,
     messageHash: messageHash,

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -11,8 +11,25 @@ const txRelayAddress =
   process.env.RELAY_CONTRACT_ADDRESS
 const txRelayABI = TxRelayContractJSON.abi
 
+const recoverAddress = async (message, signature) => {
+  const messageHash = await web3.eth.accounts.hashMessage(message)
+  // {
+  //    recoveryParam: 0,
+  //    r: "0x79f56f3422dc67f57b2aeeb0b20295a99ec90420b203177f83d419c98beda7fe",
+  //    s: "0x1a9d05433883bdc7e6d882740f4ea7921ef458a61b2cfe6197c2bb1bc47236fd"
+  // }
+
+  return web3.eth.accounts.recover({
+    messageHash: messageHash,
+    v: 27 + signature.recoveryParam, // weeeeird
+    r: signature.r,
+    s: signature.s
+  })
+}
+
 module.exports = {
   provider,
+  recoverAddress,
   txRelayAddress,
   txRelayABI
 }

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -11,20 +11,31 @@ const txRelayAddress =
   process.env.RELAY_CONTRACT_ADDRESS
 const txRelayABI = TxRelayContractJSON.abi
 
-const recoverAddress = async (message, signature) => {
-  const messageHash = await web3.eth.accounts.hashMessage(message)
-  // {
-  //    recoveryParam: 0,
-  //    r: "0x79f56f3422dc67f57b2aeeb0b20295a99ec90420b203177f83d419c98beda7fe",
-  //    s: "0x1a9d05433883bdc7e6d882740f4ea7921ef458a61b2cfe6197c2bb1bc47236fd"
+const recoverAddress = async (message, signature, key) => {  
+
+  let s = await web3.eth.accounts.sign(String(message), key)
+  console.log('eth sig', signature)
+  console.log('web3 sig', s)
+
+
+  const messageHash = await web3.eth.accounts.hashMessage(String(message))
+  
+  // signature Object {
+  //   "r": "0x5bd1a8a4e75432ed8f608f3b5a99274235b0de4bd6ab66b6a414d98a471defea",
+  //   "recoveryParam": 0,
+  //   "s": "0x3560058932986bd7cf8b06eb4614e8588e41dd6552aa41689a0f63bd393fd461",
+  //   "v": 27,
   // }
 
-  return web3.eth.accounts.recover({
+  let signatureObject = {
     messageHash: messageHash,
-    v: 27 + signature.recoveryParam, // weeeeird
-    r: signature.r,
-    s: signature.s
-  })
+    v: Web3.utils.toHex(signature.v), //27 in hex
+    r: String(signature.r),
+    s: String(signature.s)
+  }
+  console.log('signatureObject', signatureObject)
+
+  return web3.eth.accounts.recover(s)
 }
 
 module.exports = {

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3')
 const ethers = require('ethers')
-const Hash = require("eth-lib/lib/hash");
-const Account = require("eth-lib/lib/account");
+const Hash = require('eth-lib/lib/hash')
+const Account = require('eth-lib/lib/account')
 const hexStringToUint8Array = require('../lib/hexStringToUint8Array')
 const HubContractJSON = require('../../contracts/build/contracts/Hub.json')
 const TxRelayContractJSON = require('../../contracts/build/contracts/TxRelay.json')
@@ -15,23 +15,25 @@ const txRelayAddress =
   process.env.RELAY_CONTRACT_ADDRESS
 const txRelayABI = TxRelayContractJSON.abi
 
-const packSignature = (signature) => {
+const packSignature = signature => {
   return `{signature.r}{signature.s.substring(2);}{Web3.utils.toHex(ethersSignature.v).substring(2)}`
 }
 
-const recoverAddress = async (message, signature, key) => {  
-  const messageHash = await Hash.keccak256(hexStringToUint8Array(`0x${message.toString(16)}`))
-  const s = await Account.sign(messageHash, key);
-  const vrs = await Account.decodeSignature(s);
+const recoverAddress = async (message, signature, key) => {
+  const messageHash = await Hash.keccak256(
+    hexStringToUint8Array(`0x${message.toString(16)}`)
+  )
+  const s = await Account.sign(messageHash, key)
+  const vrs = await Account.decodeSignature(s)
   const web3Formatting = {
-      message: message,
-      messageHash: messageHash,
-      v: Web3.utils.toHex(signature.v),
-      r: signature.r,
-      s: signature.s,
-      signature: packSignature(signature)
-  };
-  const address = await web3.eth.accounts.recover(web3Formatting);
+    message: message,
+    messageHash: messageHash,
+    v: Web3.utils.toHex(signature.v),
+    r: signature.r,
+    s: signature.s,
+    signature: packSignature(signature)
+  }
+  const address = await web3.eth.accounts.recover(web3Formatting)
   return address
 }
 

--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -1,9 +1,4 @@
 const Web3 = require('web3')
-const ethers = require('ethers')
-const Hash = require('eth-lib/lib/hash')
-const Account = require('eth-lib/lib/account')
-const hexStringToUint8Array = require('../lib/hexStringToUint8Array')
-const HubContractJSON = require('../../contracts/build/contracts/Hub.json')
 const TxRelayContractJSON = require('../../contracts/build/contracts/TxRelay.json')
 
 const rpcUrl = require('../config/env').rpcUrl
@@ -15,29 +10,9 @@ const txRelayAddress =
   process.env.RELAY_CONTRACT_ADDRESS
 const txRelayABI = TxRelayContractJSON.abi
 
-const packSignature = signature => {
-  return `{signature.r}{signature.s.substring(2);}{Web3.utils.toHex(ethersSignature.v).substring(2)}`
-}
-
-const recoverAddress = async (message, signature) => {
-  const messageHash = await Hash.keccak256(
-    hexStringToUint8Array(`0x${message.toString(16)}`)
-  )
-  const web3Formatting = {
-    message: message,
-    messageHash: messageHash,
-    v: Web3.utils.toHex(signature.v),
-    r: signature.r,
-    s: signature.s,
-    signature: packSignature(signature)
-  }
-  const address = await web3.eth.accounts.recover(web3Formatting)
-  return address
-}
-
 module.exports = {
   provider,
-  recoverAddress,
   txRelayAddress,
-  txRelayABI
+  txRelayABI,
+  web3
 }

--- a/src/connections/cognito.js
+++ b/src/connections/cognito.js
@@ -70,13 +70,12 @@ cognito.deleteUser = deleteUserRequest => {
 }
 
 cognito.updatePhone = (username, newPhoneNumber) => {
-
   var updatePhoneParams = {
-    UserAttributes: [ 
+    UserAttributes: [
       {
         Name: 'phone_number',
         Value: newPhoneNumber
-      }      
+      }
     ],
     UserPoolId: cognitoPoolId,
     Username: username

--- a/src/connections/cognito.js
+++ b/src/connections/cognito.js
@@ -69,4 +69,25 @@ cognito.deleteUser = deleteUserRequest => {
   })
 }
 
+cognito.updatePhone = (username, newPhoneNumber) => {
+
+  var updatePhoneParams = {
+    UserAttributes: [ 
+      {
+        Name: 'phone_number',
+        Value: newPhoneNumber
+      }      
+    ],
+    UserPoolId: cognitoPoolId,
+    Username: username
+  }
+
+  return new Promise((resolve, reject) => {
+    cognitoISP.adminUpdateUserAttributes(updatePhoneParams, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
+}
+
 module.exports = cognito

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -21,7 +21,6 @@ sns.getSNSEndpoint = endpointArn => {
   const params = {
     EndpointArn: endpointArn
   }
-  console.log('arans', params)
   return new Promise((resolve, reject) => {
     sns.getEndpointAttributes(params, (err, data) => {
       if (err) reject(err)

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -17,4 +17,20 @@ sns.createSNSEndpoint = circlesUser => {
   })
 }
 
+sns.updateSNSEndpoint = (deviceEndpoint, deviceId) => {
+  const snsParams = {
+    EndpointArn: deviceEndpoint,
+    Attributes: {
+      Token: deviceId, 
+      Enabled: true
+    }
+  }
+  return new Promise((resolve, reject) => {
+    sns.setEndpointAttributes(snsParams, (err, data) => {
+      if (err) reject(err)
+      else resolve(data.EndpointArn)
+    })
+  })
+}
+
 module.exports = sns

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -21,7 +21,7 @@ sns.updateSNSEndpoint = (deviceEndpoint, deviceId) => {
   const snsParams = {
     EndpointArn: deviceEndpoint,
     Attributes: {
-      Token: deviceId, 
+      Token: deviceId,
       Enabled: true
     }
   }

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -17,7 +17,7 @@ sns.createSNSEndpoint = circlesUser => {
   })
 }
 
-sns.getSNSEndpoint = endpointArn  => {
+sns.getSNSEndpoint = endpointArn => {
   const params = {
     EndpointArn: endpointArn
   }

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -17,6 +17,19 @@ sns.createSNSEndpoint = circlesUser => {
   })
 }
 
+sns.getSNSEndpoint = endpointArn  => {
+  const params = {
+    EndpointArn: endpointArn
+  }
+  console.log('arans', params)
+  return new Promise((resolve, reject) => {
+    sns.getEndpointAttributes(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
+}
+
 sns.updateSNSEndpoint = (deviceEndpoint, deviceId) => {
   const snsParams = {
     EndpointArn: deviceEndpoint,

--- a/src/connections/sns.js
+++ b/src/connections/sns.js
@@ -35,7 +35,7 @@ sns.updateSNSEndpoint = (deviceEndpoint, deviceId) => {
     EndpointArn: deviceEndpoint,
     Attributes: {
       Token: deviceId,
-      Enabled: true
+      Enabled: 'true'
     }
   }
   return new Promise((resolve, reject) => {

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -2,7 +2,7 @@ const PostgresDB = require('../database').postgresDB
 const User = require('../models/user')
 const logger = require('../lib/logger')
 const cognitoISP = require('../connections/cognito')
-const recoverAddress = require('../connections/blockchain')
+const { recoverAddress } = require('../connections/blockchain')
 const sns = require('../connections/sns')
 const convertCognitoToCirclesUser = require('../lib/convertCognitoToCirclesUser')
 
@@ -176,12 +176,15 @@ async function deleteOwn (req, res) {
 }
 
 async function recoverAccount (req, res) {
+  console.log('recoverAccount')
   try {
     // todo: add security
     const walletAddress = await recoverAddress(
+      req.body.message,
       req.body.signature,
-      req.body.message
+      req.body.key
     )
+    logger.info('walletAddress: ' + walletAddress)
 
     const user = await User.query()
       .where({ wallet_address: walletAddress })

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -2,6 +2,7 @@ const PostgresDB = require('../database').postgresDB
 const User = require('../models/user')
 const logger = require('../lib/logger')
 const cognitoISP = require('../connections/cognito')
+const recoverAddress = require('../connections/blockchain')
 const sns = require('../connections/sns')
 const convertCognitoToCirclesUser = require('../lib/convertCognitoToCirclesUser')
 
@@ -177,8 +178,13 @@ async function deleteOwn (req, res) {
 async function recoverAccount (req, res) {
   try {
     // todo: add security
+    const walletAddress = await recoverAddress(
+      req.body.signature,
+      req.body.message
+    )
+
     const user = await User.query()
-      .where({ wallet_address: req.params.wallet_address })
+      .where({ wallet_address: walletAddress })
       .first()
     if (!user) return res.sendStatus(404)
 

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -217,7 +217,10 @@ async function recoverAccount (req, res) {
 
     console.log('endpointData', endpointData.toJson())
 
-    if (user.device_id !== endpointData.Attributes.Token || !endpointData.Attributes.Enabled) {
+    if (
+      user.device_id !== endpointData.Attributes.Token ||
+      !endpointData.Attributes.Enabled
+    ) {
       // update sns endpoint with new device token
       const endpointArn = await sns.updateSNSEndpoint(
         user.device_endpoint,
@@ -233,7 +236,7 @@ async function recoverAccount (req, res) {
 
       user = await user.patchAndFetchById(user.id, {
         phone_number: req.body.phone_number || user.phone_number,
-        device_endpoint: endpointArn        
+        device_endpoint: endpointArn
       })
       logger.info('user ' + user)
     }

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -2,7 +2,7 @@ const PostgresDB = require('../database').postgresDB
 const User = require('../models/user')
 const logger = require('../lib/logger')
 const cognitoISP = require('../connections/cognito')
-const { recoverAddress } = require('../connections/blockchain')
+const { recoverAddress } = require('../lib/blockchain')
 const sns = require('../connections/sns')
 const convertCognitoToCirclesUser = require('../lib/convertCognitoToCirclesUser')
 
@@ -179,7 +179,7 @@ async function recoverAccount (req, res) {
   try {
     const now = Date.now()
     // if timestamp message is more than 2.5 minutes ago or in the future send FORBIDDEN
-    if (req.body.message < now - 150 || req.body.message > now)
+    if (req.body.message < now-150000 || req.body.message > now)
       return res.sendStatus(403)
 
     const walletAddress = await recoverAddress(
@@ -258,14 +258,14 @@ async function recoverAccount (req, res) {
 
 async function getSuggestedContacts (req, res) {
   try {
-    let contacts = JSON.parse(req.body.contacts)
-    let numbers = contacts.map(contact => contact.number)
+    const contacts = JSON.parse(req.body.contacts)
+    const numbers = contacts.map(contact => contact.number)
     const users = await User.query()
       .whereIn('phone_number', numbers)
       .andWhere('agreed_to_disclaimer', true)
     if (!users) return res.sendStatus(404)
-    let suggestedNumbers = users.map(user => user.phone_number)
-    let suggestedContacts = contacts.filter(contact =>
+    const suggestedNumbers = users.map(user => user.phone_number)
+    const suggestedContacts = contacts.filter(contact =>
       suggestedNumbers.includes(contact.number)
     )
     res.status(200).send(suggestedContacts)

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -206,7 +206,7 @@ async function recoverAccount (req, res) {
           user.device_endpoint,
           req.body.device_id
         )
-        logger.info('updating endpointArn ' + endpointArn)
+        logger.debug('updating endpointArn ' + endpointArn)
         updateUserObj.device_endpoint = endpointArn
         updateUserObj.device_id = req.body.device_id
       }
@@ -239,7 +239,7 @@ async function recoverAccount (req, res) {
         user.username,
         req.body.phone_number
       )
-      logger.info('updating phone_number ' + res)
+      logger.debug('updating phone_number ' + res)
       updateUserObj.phone_number = req.body.phone_number
     }
 

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -182,8 +182,16 @@ async function recoverAccount (req, res) {
       .first()
     if (!user) return res.sendStatus(404)
 
-    logger.info((user.device_endpoint === req.body.device_endpoint), user.device_endpoint, req.body.device_endpoint)
-    logger.info((user.phone_number === req.body.phone_number), user.phone_number, req.body.phone_number)
+    logger.info(
+      user.device_endpoint === req.body.device_endpoint,
+      user.device_endpoint,
+      req.body.device_endpoint
+    )
+    logger.info(
+      user.phone_number === req.body.phone_number,
+      user.phone_number,
+      req.body.phone_number
+    )
 
     await user.$relatedQuery('notifications')
     await user.$relatedQuery('offers')
@@ -191,13 +199,22 @@ async function recoverAccount (req, res) {
 
     if (user.phone_number !== req.body.phone_number) {
       // update sns endpoint with new device token
-      const endpointArn = await sns.updateSNSEndpoint(user.device_endpoint, req.body.device_id)
+      const endpointArn = await sns.updateSNSEndpoint(
+        user.device_endpoint,
+        req.body.device_id
+      )
       logger.info('endpointArn ' + endpointArn)
       // update cognito with new phone number and trigger verification
-      const res = await cognitoISP.updatePhone(user.username, req.body.phone_number)
+      const res = await cognitoISP.updatePhone(
+        user.username,
+        req.body.phone_number
+      )
       logger.info('updatePhone ' + res)
 
-      user = await user.patchAndFetchById(user.id, {phone_number: (req.body.phone_number || user.phone_number) , device_endpoint: endpointArn})
+      user = await user.patchAndFetchById(user.id, {
+        phone_number: req.body.phone_number || user.phone_number,
+        device_endpoint: endpointArn
+      })
       logger.info('user ' + user)
     }
     res.status(200).send(user)

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -178,8 +178,8 @@ async function deleteOwn (req, res) {
 async function recoverAccount (req, res) {
   try {
     const now = Date.now()
-    // if timestamp message is more than 2.5 minutes ago or more than 2.5 mins from now
-    if (req.body.message < now - 150 || req.body.message > now + 150)
+    // if timestamp message is more than 2.5 minutes ago or in the future send FORBIDDEN
+    if (req.body.message < now - 150 || req.body.message > now)
       return res.sendStatus(403)
 
     const walletAddress = await recoverAddress(

--- a/src/lib/hexStringToUint8Array.js
+++ b/src/lib/hexStringToUint8Array.js
@@ -1,0 +1,35 @@
+function addSlice(array) {
+  if (array.slice) {
+    return array;
+  }
+  array.slice = function () {
+    const args = Array.prototype.slice.call(arguments);
+    return addSlice(new Uint8Array(Array.prototype.slice.apply(array, args)));
+  };
+  return array;
+}
+
+const hexStringToUint8Array = (value) => {
+  const match = value.match(/^(0x)?[0-9a-fA-F]*$/);
+  if (!match) {
+    throw('invalid hexidecimal string', errors.INVALID_ARGUMENT, { arg: 'value', value: value });
+  }
+  if (match[1] !== '0x') {
+    throw('hex string must have 0x prefix', errors.INVALID_ARGUMENT, { arg: 'value', value: value });
+  }
+  value = value.substring(2);
+  if (value.length % 2) {
+      value = '0' + value;
+  }
+  console.log(value)
+  const result = [];
+  for (let i = 0; i < value.length; i += 2) {
+      result.push(parseInt(value.substr(i, 2), 16));
+  }
+  console.log(result)
+  const sliced = addSlice(new Uint8Array(result));
+  console.log(sliced)
+  return sliced
+}
+
+module.exports = hexStringToUint8Array;

--- a/src/lib/hexStringToUint8Array.js
+++ b/src/lib/hexStringToUint8Array.js
@@ -25,14 +25,11 @@ const hexStringToUint8Array = value => {
   if (value.length % 2) {
     value = '0' + value
   }
-  console.log(value)
   const result = []
   for (let i = 0; i < value.length; i += 2) {
     result.push(parseInt(value.substr(i, 2), 16))
   }
-  console.log(result)
   const sliced = addSlice(new Uint8Array(result))
-  console.log(sliced)
   return sliced
 }
 

--- a/src/lib/hexStringToUint8Array.js
+++ b/src/lib/hexStringToUint8Array.js
@@ -1,35 +1,39 @@
-function addSlice(array) {
+function addSlice (array) {
   if (array.slice) {
-    return array;
+    return array
   }
   array.slice = function () {
-    const args = Array.prototype.slice.call(arguments);
-    return addSlice(new Uint8Array(Array.prototype.slice.apply(array, args)));
-  };
-  return array;
+    const args = Array.prototype.slice.call(arguments)
+    return addSlice(new Uint8Array(Array.prototype.slice.apply(array, args)))
+  }
+  return array
 }
 
-const hexStringToUint8Array = (value) => {
-  const match = value.match(/^(0x)?[0-9a-fA-F]*$/);
+const hexStringToUint8Array = value => {
+  const match = value.match(/^(0x)?[0-9a-fA-F]*$/)
   if (!match) {
-    throw('invalid hexidecimal string', errors.INVALID_ARGUMENT, { arg: 'value', value: value });
+    throw ('invalid hexidecimal string',
+    errors.INVALID_ARGUMENT,
+    { arg: 'value', value: value })
   }
   if (match[1] !== '0x') {
-    throw('hex string must have 0x prefix', errors.INVALID_ARGUMENT, { arg: 'value', value: value });
+    throw ('hex string must have 0x prefix',
+    errors.INVALID_ARGUMENT,
+    { arg: 'value', value: value })
   }
-  value = value.substring(2);
+  value = value.substring(2)
   if (value.length % 2) {
-      value = '0' + value;
+    value = '0' + value
   }
   console.log(value)
-  const result = [];
+  const result = []
   for (let i = 0; i < value.length; i += 2) {
-      result.push(parseInt(value.substr(i, 2), 16));
+    result.push(parseInt(value.substr(i, 2), 16))
   }
   console.log(result)
-  const sliced = addSlice(new Uint8Array(result));
+  const sliced = addSlice(new Uint8Array(result))
   console.log(sliced)
   return sliced
 }
 
-module.exports = hexStringToUint8Array;
+module.exports = hexStringToUint8Array

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,6 +12,8 @@ const relayerRouter = require('./relayerRouter')
 
 const apiVersionString = require('../config/env').apiVersionString
 
+const usersController = require('../controllers/usersController')
+
 module.exports = function (app) {
   app.use(cors())
   app.use(bodyParser.urlencoded({ extended: true }))
@@ -20,6 +22,9 @@ module.exports = function (app) {
   app.get('/', (req, res) => res.status(200).json('hello Ed!'))
 
   app.use(loggingMiddleware)
+
+  app.use('/' + apiVersionString + '/users/recovery', usersController.recoverAccount)
+
   app.use(authMiddleware)
 
   app.use('/' + apiVersionString + '/admin', adminRouter)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -23,7 +23,10 @@ module.exports = function (app) {
 
   app.use(loggingMiddleware)
 
-  app.use('/' + apiVersionString + '/users/recovery', usersController.recoverAccount)
+  app.use(
+    '/' + apiVersionString + '/users/recovery',
+    usersController.recoverAccount
+  )
 
   app.use(authMiddleware)
 

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -13,4 +13,6 @@ router.delete(
   usersController.deleteOwn
 )
 
+router.post('/recover/:wallet_address', usersController.recoverAccount)
+
 module.exports = router

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -13,6 +13,6 @@ router.delete(
   usersController.deleteOwn
 )
 
-router.post('/recover/:wallet_address', usersController.recoverAccount)
+router.post('/recover', usersController.recoverAccount)
 
 module.exports = router

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -13,6 +13,4 @@ router.delete(
   usersController.deleteOwn
 )
 
-router.post('/recover', usersController.recoverAccount)
-
 module.exports = router

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -95,7 +95,8 @@ router.delete(
  * @apiSuccess (Success 200) {String} contacts.id   Phone specific contact Id.
  * @apiSuccess (Success 200) {String} contacts.number Phone number of contact.
  */
-router.post('/contacts', 
+router.post(
+  '/contacts',
   hasPermissionMiddleware('ownUser'),
   usersController.getSuggestedContacts
 )

--- a/src/seeds/all_tables.js.old
+++ b/src/seeds/all_tables.js.old
@@ -5,11 +5,11 @@ const {
   createFakeNotification
 } = require('./helpers/fakers')
 
-const fakeUsers = []
-const requiredUsers = 5
+const requiredUsers = 10
+const fakeUsers = [...new Array(requiredUsers)]
 
-const fakeOrganizations = []
 const requiredOrganizations = 2
+let fakeOrganizations = [...new Array(requiredOrganizations)]
 
 let fakeUserOrgs = []
 
@@ -22,66 +22,93 @@ const offersPerOrg = 3
 
 exports.seed = function (knex, Promise) {
   // Deletes ALL existing entries
-  return Promise.all([
-    knex('organization').del(),
-    knex('users').del(),
-    knex('user_organizations').del(),
-    knex('notification').del(),
-    knex('offer').del()
-  ])
-    .then(() => {
-      for (let i = 0; i < requiredUsers; i++) {
-        const u = createFakeUser()
-        // saving enough userIds so I can associate each
-        // org with a user in the 'user_organizations' join table
-        if (i < requiredOrganizations) {
-          fakeUserOrgs.push({ user_id: u.id })
+  return (
+    Promise.all([
+      knex('organization').del(),
+      knex('users').del(),
+      knex('user_organizations').del(),
+      knex('notification').del(),
+      knex('offer').del()
+    ])
+      .then(() => {
+        let b = createFakeUser()
+        fakeUsers.map(u => {
+          u = createFakeUser()
+          return u
+        })
+        console.log(fakeUsers, b)
+        return knex('users').insert(fakeUsers)
+      })
+      .then(() => {
+        fakeOrganizations.map((blank, i) => {
+          let org = createFakeOrganization()
+          // 1/2 have just an owner
+          org.owner_id = fakeUsers[i].id
+          if (i > requiredOrganizations / 2) {
+            // 1/2 have an owner and {rand amt} members
+            let amt = Math.ciel(Math.random * 10)
+            for (let j = 0; j < amt; j++) {
+              //pick a rand user
+              let member
+              while (!member) {
+                const randUser =
+                  fakeUsers[Math.floor(Math.random * fakeUsers.length)]
+                // can't pick the owner
+                member = randUser.id != org.owner_id ? randUser : undefined
+              }
+              fakeUserOrgs.push({
+                organization_id: org.id,
+                user_id: member.id
+              })
+            }
+          }
+          return org
+        })
+
+        return knex('organization').insert(fakeOrganizations)
+      })
+      // .then(() => {
+      //   for (let i = 0; i < requiredOrganizations; i++) {
+      //     const o = createFakeOrganization()
+      //     o.owner_id = fakeUsers[i].id
+      //     fakeUserOrgs[i].organization_id = o.id
+      //     fakeOrganizations.push(o)
+      //   }
+      //   return knex('organization').insert(fakeOrganizations)
+      // })
+      .then(() => {
+        return knex('user_organizations').insert(fakeUserOrgs)
+      })
+      .then(() => {
+        for (let i = 0; i < fakeUsers.length; i++) {
+          for (let j = 0; j < notificationsPerUser; j++) {
+            const n = createFakeNotification()
+            n.user_id = fakeUsers[i].id
+            fakeNotifications.push(n)
+          }
         }
-        fakeUsers.push(u)
-      }
-      return knex('users').insert(fakeUsers)
-    })
-    .then(() => {
-      for (let i = 0; i < requiredOrganizations; i++) {
-        const o = createFakeOrganization()
-        o.owner_id = fakeUsers[i].id
-        fakeUserOrgs[i].organization_id = o.id
-        fakeOrganizations.push(o)
-      }
-      return knex('organization').insert(fakeOrganizations)
-    })
-    .then(() => {
-      return knex('user_organizations').insert(fakeUserOrgs)
-    })
-    .then(() => {
-      for (let i = 0; i < fakeUsers.length; i++) {
-        for (let j = 0; j < notificationsPerUser; j++) {
-          const n = createFakeNotification()
-          n.user_id = fakeUsers[i].id
-          fakeNotifications.push(n)
+        return knex('notification').insert(fakeNotifications)
+      })
+      .then(() => {
+        for (let i = 0; i < fakeUsers.length; i++) {
+          for (let j = 0; j < offersPerUser; j++) {
+            const o = createFakeOffer()
+            o.owner_id = fakeUsers[i].id
+            fakeOffers.push(o)
+          }
         }
-      }
-      return knex('notification').insert(fakeNotifications)
-    })
-    .then(() => {
-      for (let i = 0; i < fakeUsers.length; i++) {
-        for (let j = 0; j < offersPerUser; j++) {
-          const o = createFakeOffer()
-          o.owner_id = fakeUsers[i].id
-          fakeOffers.push(o)
+        return knex('offer').insert(fakeOffers)
+      })
+      .then(() => {
+        fakeOffers = []
+        for (let i = 0; i < fakeOrganizations.length; i++) {
+          for (let j = 0; j < offersPerOrg; j++) {
+            const o = createFakeOffer()
+            o.owner_id = fakeOrganizations[i].id
+            fakeOffers.push(o)
+          }
         }
-      }
-      return knex('offer').insert(fakeOffers)
-    })
-    .then(() => {
-      fakeOffers = []
-      for (let i = 0; i < fakeOrganizations.length; i++) {
-        for (let j = 0; j < offersPerOrg; j++) {
-          const o = createFakeOffer()
-          o.owner_id = fakeOrganizations[i].id
-          fakeOffers.push(o)
-        }
-      }
-      return knex('offer').insert(fakeOffers)
-    })
+        return knex('offer').insert(fakeOffers)
+      })
+  )
 }

--- a/src/seeds/all_tables.js.old
+++ b/src/seeds/all_tables.js.old
@@ -36,7 +36,6 @@ exports.seed = function (knex, Promise) {
           u = createFakeUser()
           return u
         })
-        console.log(fakeUsers, b)
         return knex('users').insert(fakeUsers)
       })
       .then(() => {

--- a/src/seeds/cognito_test_user.js
+++ b/src/seeds/cognito_test_user.js
@@ -35,7 +35,7 @@ exports.seed = function (knex, Promise) {
           'http://ribstf.org/wp-content/uploads/2015/11/empty-profile-pic.png',
         device_id: 'test_device_id',
         agreed_to_disclaimer: true // used for legal reasons, and to denote that the user has been fully set up
-      }      
+      }
       return knex('users').insert(testUser)
     })
     .then(() => {

--- a/src/seeds/cognito_test_user.js
+++ b/src/seeds/cognito_test_user.js
@@ -23,26 +23,19 @@ exports.seed = function (knex, Promise) {
   ])
     .then(() => {
       testUser = {
-        id: 'test',
+        id: '96b05fb0-13a1-4acb-8f39-505a7dedbcda',
         username: 'test',
         display_name: 'Test User',
-        wallet_address: '0x',
+        wallet_address: '0x571707f398847bEaD4113d334780945E0Bd2c72F',
         token_address: '0x',
         name: 'Test User',
         phone_number: '+111111111111111111',
         email: 'test@joincircles.net',
         profile_pic_url:
           'http://ribstf.org/wp-content/uploads/2015/11/empty-profile-pic.png',
-        device_id: 'test_device_id'
-      }
-      //   id: '96b05fb0-13a1-4acb-8f39-505a7dedbcda',
-      //   agreed_to_disclaimer: true, // used for legal reasons, and to denote that the user has been fully set up
-      //   display_name: 'testuser',
-      //   email: 'test@joincircles.net',
-      //   profile_pic_url: 'testuser',
-      //   device_id: 'deviceid',
-      //   phone_number: '+00111111111111111'
-      // }
+        device_id: 'test_device_id',
+        agreed_to_disclaimer: true // used for legal reasons, and to denote that the user has been fully set up
+      }      
       return knex('users').insert(testUser)
     })
     .then(() => {


### PR DESCRIPTION
## FE
`AuthSaga initRecoverAccount()` signs a message (a timestamp) and sends to API. `phone_number` and `device_id` sent in case of phone number or device change.
```
        body: {
          message: message,
          signature: signature,
          device_id: DeviceInfo.getUniqueID(),
          phone_number: phone
        }
```
## API
`usersController.recoverAccount()` logic overview:
1. Check `message` to see if timestamp is less than 2.5 minutes old and not in the future. If fail then send 403
2. `recoverAddress()` from `message` and `signature`
3. Search DB for address. If not exist then send 404
4. `getSNSEndpoint()` from aws sns
5. If not exist or malformed then `createSNSEndpoint()`
6. Else, if `device_id` has changed then `updateSNSEndpoint`
7. Check if `phone_number` has changed then `updatePhone()` on aws cognito
8. Save updated fields to DB
9. Return updated `user` to FE

At this point the user is signed out and will need to sign in or even use forgot password to recover the login credentials.

## Questions
I am not sure how to configure the route for this endpoint. The user does not need/have a token when recovering and therefore does not have groups either. That implies an open endpoint but that seems dangerous


