### PR TITLE
change from http to ws rpc provider

### DIFF
--- a/src/connections/blockchain.js
+++ b/src/connections/blockchain.js
@@ -3,7 +3,7 @@ const HubContractJSON = require('../../contracts/build/contracts/Hub.json')
 const TxRelayContractJSON = require('../../contracts/build/contracts/TxRelay.json')
 
 const rpcUrl = require('../config/env').rpcUrl
-const provider = new Web3.providers.HttpProvider(rpcUrl)
+const provider = new Web3.providers.WebsocketProvider(rpcUrl)
 const web3 = new Web3(provider)
 
 const txRelayAddress =


### PR DESCRIPTION
I was having problems connecting to ganache so I replaced the httpprovider as it is depecated.
https://web3js.readthedocs.io/en/1.0/web3.html#value

